### PR TITLE
add some minor tests around Bundle and BundleControl error cases

### DIFF
--- a/bundleControl_test.go
+++ b/bundleControl_test.go
@@ -94,6 +94,30 @@ func TestParseBundleControl(t *testing.T) {
 	}
 }
 
+func TestParseBundleControlError(t *testing.T) {
+	bc := NewBundleControl()
+	bc.Parse(" invalid line ")
+
+	if bc.BundleItemsCount != 0 {
+		t.Errorf("unexpcted BundleItemsCount=%d", bc.BundleItemsCount)
+	}
+	if bc.BundleTotalAmount != 0 {
+		t.Errorf("unexpcted BundleTotalAmount=%d", bc.BundleTotalAmount)
+	}
+	if bc.MICRValidTotalAmount != 0 {
+		t.Errorf("unexpcted MICRValidTotalAmount=%d", bc.MICRValidTotalAmount)
+	}
+	if bc.BundleImagesCount != 0 {
+		t.Errorf("unexpcted BundleImagesCount=%d", bc.BundleImagesCount)
+	}
+	if bc.UserField != "" {
+		t.Errorf("unexpcted UserField=%s", bc.UserField)
+	}
+	if bc.CreditTotalIndicator != 0 {
+		t.Errorf("unexpcted CreditTotalIndicator=%d", bc.CreditTotalIndicator)
+	}
+}
+
 // testBCString validates that a known parsed BundleControl can be return to a string of the same value
 func testBCString(t testing.TB) {
 	var line = "70000100000010000000000000000000000                    0                        "

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -57,6 +57,14 @@ func TestMockBundleReturns(t *testing.T) {
 	}
 }
 
+func TestBundleValidate(t *testing.T) {
+	header := mockBundleHeader()
+	bundle := NewBundle(header)
+	if err := bundle.Validate(); err == nil {
+		t.Error("expected error, but got nothing")
+	}
+}
+
 // TestCheckDetailAddendumCount validates CheckDetail AddendumCount
 func TestCheckDetailAddendumCount(t *testing.T) {
 	cd := mockCheckDetail()


### PR DESCRIPTION
These were found with Go's coverage tools (missing test coverage).