### PR TITLE
all: check record lengths before parsing them

### DIFF
--- a/CheckDetailAddendumC.go
+++ b/CheckDetailAddendumC.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Errors specific to a CheckDetailAddendumC Record
@@ -98,6 +99,10 @@ func NewCheckDetailAddendumC() CheckDetailAddendumC {
 
 // Parse takes the input record string and parses the CheckDetailAddendumC values
 func (cdAddendumC *CheckDetailAddendumC) Parse(record string) {
+	if utf8.RuneCountInString(record) < 60 {
+		return // line too short
+	}
+
 	// Character position 1-2, Always "28"
 	cdAddendumC.recordType = "28"
 	// 03-04

--- a/checkDetail.go
+++ b/checkDetail.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // Errors specific to a CheckDetail Record
@@ -162,6 +163,10 @@ func NewCheckDetail() *CheckDetail {
 
 // Parse takes the input record string and parses the CheckDetail values
 func (cd *CheckDetail) Parse(record string) {
+	if utf8.RuneCountInString(record) < 80 {
+		return // line too short
+	}
+
 	// Character position 1-2, Always "25"
 	cd.recordType = "25"
 	// 03-17

--- a/checkDetailAddendumA.go
+++ b/checkDetailAddendumA.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Errors specific to a CheckDetailAddendumA Record
@@ -94,6 +95,10 @@ func NewCheckDetailAddendumA() CheckDetailAddendumA {
 
 // Parse takes the input record string and parses the CheckDetailAddendumA values
 func (cdAddendumA *CheckDetailAddendumA) Parse(record string) {
+	if utf8.RuneCountInString(record) < 77 {
+		return // line too short
+	}
+
 	// Character position 1-2, Always "26"
 	cdAddendumA.recordType = "26"
 	// 03-03

--- a/checkDetailAddendumA_test.go
+++ b/checkDetailAddendumA_test.go
@@ -28,6 +28,14 @@ func mockCheckDetailAddendumA() CheckDetailAddendumA {
 	return cdAddendumA
 }
 
+func TestCheckDetailAddendumParseErr(t *testing.T) {
+	var c CheckDetailAddendumA
+	c.Parse("asdshfaksjs")
+	if c.RecordNumber != 0 {
+		t.Errorf("c.RecordNumber=%d", c.RecordNumber)
+	}
+}
+
 // TestMockCheckDetailAddendumA creates a CheckDetailAddendumA
 func TestMockCheckDetailAddendumA(t *testing.T) {
 	cdAddendumA := mockCheckDetailAddendumA()

--- a/checkDetailAddendumB_test.go
+++ b/checkDetailAddendumB_test.go
@@ -22,6 +22,21 @@ func mockCheckDetailAddendumB() CheckDetailAddendumB {
 	return cdAddendumB
 }
 
+func TestCheckDetailAddendumBParseErr(t *testing.T) {
+	var c CheckDetailAddendumB
+	c.Parse("asdhfakjfsa")
+	if c.ImageReferenceKeyIndicator != 0 {
+		t.Errorf("c.ImageReferenceKeyIndicator=%d", c.ImageReferenceKeyIndicator)
+	}
+	c.Parse("2711A             00340                                 CD Addendum B")
+	if c.ImageReferenceKeyIndicator != 1 {
+		t.Errorf("c.ImageReferenceKeyIndicator=%d", c.ImageReferenceKeyIndicator)
+	}
+	if c.ImageReferenceKey != "" {
+		t.Errorf("c.ImageReferenceKey=%s", c.ImageReferenceKey)
+	}
+}
+
 // TestMockCheckDetailAddendumB creates a CheckDetailAddendumB
 func TestMockCheckDetailAddendumB(t *testing.T) {
 	cdAddendumB := mockCheckDetailAddendumB()

--- a/checkDetailAddendumC_test.go
+++ b/checkDetailAddendumC_test.go
@@ -65,6 +65,14 @@ func TestMockCheckDetailAddendumC(t *testing.T) {
 	}
 }
 
+func TestParseCheckDetailAddendumCErr(t *testing.T) {
+	var c CheckDetailAddendumC
+	c.Parse("asdsakjahsfa")
+	if c.RecordNumber != 0 {
+		t.Errorf("c.RecordNumber=%d", c.RecordNumber)
+	}
+}
+
 // TestParseCheckDetailAddendumC validates parsing a CheckDetailAddendumC
 func TestParseCheckDetailAddendumC(t *testing.T) {
 	var line = "2801121042882201809051              Y10A                   0                    "

--- a/checkDetail_test.go
+++ b/checkDetail_test.go
@@ -29,6 +29,14 @@ func mockCheckDetail() *CheckDetail {
 	return cd
 }
 
+func TestCheckDetailParseErr(t *testing.T) {
+	var c CheckDetail
+	c.Parse("jakjsakjfas")
+	if c.AuxiliaryOnUs != "" {
+		t.Errorf("c.AuxiliaryOnUs=%s", c.AuxiliaryOnUs)
+	}
+}
+
 // TestMockCheckDetail creates a CheckDetail
 func TestMockCheckDetail(t *testing.T) {
 	cd := mockCheckDetail()

--- a/returnDetail.go
+++ b/returnDetail.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Errors specific to a ReturnDetail Record
@@ -170,6 +171,10 @@ func NewReturnDetail() *ReturnDetail {
 
 // Parse takes the input record string and parses the ReturnDetail values
 func (rd *ReturnDetail) Parse(record string) {
+	if utf8.RuneCountInString(record) < 72 {
+		return // line too short
+	}
+
 	// Character position 1-2, Always "31"
 	rd.recordType = "31"
 	// 03-10

--- a/returnDetailAddendumA.go
+++ b/returnDetailAddendumA.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Errors specific to a ReturnDetailAddendumA Record
@@ -96,6 +97,10 @@ func NewReturnDetailAddendumA() ReturnDetailAddendumA {
 
 // Parse takes the input record string and parses the ReturnDetailAddendumA values
 func (rdAddendumA *ReturnDetailAddendumA) Parse(record string) {
+	if utf8.RuneCountInString(record) < 77 {
+		return // line too short
+	}
+
 	// Character position 1-2, Always "32"
 	rdAddendumA.recordType = "32"
 	// 03-03

--- a/returnDetailAddendumA_test.go
+++ b/returnDetailAddendumA_test.go
@@ -28,6 +28,14 @@ func mockReturnDetailAddendumA() ReturnDetailAddendumA {
 	return rdAddendumA
 }
 
+func TestReturnDetailAddendumAParseErr(t *testing.T) {
+	var r ReturnDetailAddendumA
+	r.Parse("asdlsajhfakjfa")
+	if r.RecordNumber != 0 {
+		t.Errorf("r.RecordNumber=%d", r.RecordNumber)
+	}
+}
+
 // TestMockReturnDetailAddendumA creates a ReturnDetailAddendumA
 func TestMockReturnDetailAddendumA(t *testing.T) {
 	rdAddendumA := mockReturnDetailAddendumA()

--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Errors specific to a ReturnDetailAddendumB Record
@@ -49,6 +50,10 @@ func NewReturnDetailAddendumB() ReturnDetailAddendumB {
 
 // Parse takes the input record string and parses the ReturnDetailAddendumB values
 func (rdAddendumB *ReturnDetailAddendumB) Parse(record string) {
+	if utf8.RuneCountInString(record) < 80 {
+		return // line too short
+	}
+
 	// Character position 1-2, Always "33"
 	rdAddendumB.recordType = "33"
 	// 03-20
@@ -61,7 +66,6 @@ func (rdAddendumB *ReturnDetailAddendumB) Parse(record string) {
 	rdAddendumB.PayorBankBusinessDate = rdAddendumB.parseYYYYMMDDDate(record[50:58])
 	// 59-80
 	rdAddendumB.PayorAccountName = rdAddendumB.parseStringField(record[58:80])
-
 }
 
 // String writes the ReturnDetailAddendumB struct to a string.

--- a/returnDetailAddendumB_test.go
+++ b/returnDetailAddendumB_test.go
@@ -22,6 +22,14 @@ func mockReturnDetailAddendumB() ReturnDetailAddendumB {
 	return rdAddendumB
 }
 
+func TestReturnDetailAddendumBParseErr(t *testing.T) {
+	var r ReturnDetailAddendumB
+	r.Parse("Asdjashfakjfa")
+	if r.PayorBankName != "" {
+		t.Errorf("r.PayorBankName=%s", r.PayorBankName)
+	}
+}
+
 // TestMockReturnDetailAddendumB creates a ReturnDetailAddendumB
 func TestMockReturnDetailAddendumB(t *testing.T) {
 	rdAddendumB := mockReturnDetailAddendumB()

--- a/returnDetailAddendumC_test.go
+++ b/returnDetailAddendumC_test.go
@@ -22,6 +22,21 @@ func mockReturnDetailAddendumC() ReturnDetailAddendumC {
 	return rdAddendumC
 }
 
+func TestReturnDetailAddendumCParseErr(t *testing.T) {
+	var r ReturnDetailAddendumC
+	r.Parse("ASdsadasda")
+	if r.ImageReferenceKeyIndicator != 0 {
+		t.Errorf("r.ImageReferenceKeyIndicator=%d", r.ImageReferenceKeyIndicator)
+	}
+	r.Parse("3411A             00340                                 RD Addendum C")
+	if r.ImageReferenceKeyIndicator != 1 {
+		t.Errorf("r.ImageReferenceKeyIndicator=%d", r.ImageReferenceKeyIndicator)
+	}
+	if r.ImageReferenceKey != "" {
+		t.Errorf("r.ImageReferenceKey=%s", r.ImageReferenceKey)
+	}
+}
+
 // TestMockReturnDetailAddendumCcreates a ReturnDetailAddendumC
 func TestMockReturnDetailAddendumC(t *testing.T) {
 	rdAddendumC := mockReturnDetailAddendumC()

--- a/returnDetailAddendumD.go
+++ b/returnDetailAddendumD.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Errors specific to a ReturnDetailAddendumD Record
@@ -98,6 +99,10 @@ func NewReturnDetailAddendumD() ReturnDetailAddendumD {
 
 // Parse takes the input record string and parses the ReturnDetailAddendumD values
 func (rdAddendumD *ReturnDetailAddendumD) Parse(record string) {
+	if utf8.RuneCountInString(record) < 60 {
+		return // line too short
+	}
+
 	// Character position 1-2, Always "35"
 	rdAddendumD.recordType = "35"
 	// 03-04

--- a/returnDetailAddendumD_test.go
+++ b/returnDetailAddendumD_test.go
@@ -27,6 +27,14 @@ func mockReturnDetailAddendumD() ReturnDetailAddendumD {
 	return rdAddendumD
 }
 
+func TestReturnDetailAddendumDParseErr(t *testing.T) {
+	var r ReturnDetailAddendumD
+	r.Parse("ASdasdas")
+	if r.RecordNumber != 0 {
+		t.Errorf("r.RecordNumber=%d", r.RecordNumber)
+	}
+}
+
 // TestMockReturnDetailAddendumD creates a ReturnDetailAddendumD
 func TestMockReturnDetailAddendumD(t *testing.T) {
 	rdAddendumD := mockReturnDetailAddendumD()

--- a/returnDetail_test.go
+++ b/returnDetail_test.go
@@ -30,6 +30,14 @@ func mockReturnDetail() *ReturnDetail {
 	return rd
 }
 
+func TestReturnDetailParse(t *testing.T) {
+	var r ReturnDetail
+	r.Parse("asshafaksjfas")
+	if r.PayorBankRoutingNumber != "" {
+		t.Errorf("r.PayorBankRoutingNumber=%s", r.PayorBankRoutingNumber)
+	}
+}
+
 // TestMockReturnDetail creates a ReturnDetail
 func TestMockReturnDetail(t *testing.T) {
 	rd := mockReturnDetail()

--- a/routingNumberSummary.go
+++ b/routingNumberSummary.go
@@ -7,6 +7,7 @@ package imagecashletter
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // RoutingNumberSummary Record
@@ -40,6 +41,10 @@ func NewRoutingNumberSummary() *RoutingNumberSummary {
 
 // Parse takes the input record string and parses the ImageViewDetail values
 func (rns *RoutingNumberSummary) Parse(record string) {
+	if utf8.RuneCountInString(record) < 55 {
+		return // line too short
+	}
+
 	// Character position 1-2, Always "85"
 	rns.recordType = "85"
 	// 03-11

--- a/routingNumberSummary_test.go
+++ b/routingNumberSummary_test.go
@@ -20,6 +20,14 @@ func mockRoutingNumberSummary() *RoutingNumberSummary {
 	return rns
 }
 
+func TestRoutingNumberSummaryParseErr(t *testing.T) {
+	var r RoutingNumberSummary
+	r.Parse("asdlahsakjajf")
+	if r.CashLetterRoutingNumber != "" {
+		t.Errorf("r.CashLetterRoutingNumber=%s", r.CashLetterRoutingNumber)
+	}
+}
+
 // TestRoutingNumberSummary creates a ReturnRoutingNumberSummary
 func TestRoutingNumberSummary(t *testing.T) {
 	rns := mockRoutingNumberSummary()

--- a/userGeneral.go
+++ b/userGeneral.go
@@ -7,6 +7,7 @@ package imagecashletter
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // Errors specific to a UserGeneral Record
@@ -88,6 +89,10 @@ func NewUserGeneral() *UserGeneral {
 
 // Parse takes the input record string and parses the UserGeneral values
 func (ug *UserGeneral) Parse(record string) {
+	if utf8.RuneCountInString(record) < 45 {
+		return // line too short
+	}
+
 	// Character position 1-2, Always "68"
 	ug.recordType = "68"
 	// 03-03

--- a/userGeneral_test.go
+++ b/userGeneral_test.go
@@ -22,6 +22,14 @@ func mockUserGeneral() *UserGeneral {
 	return ug
 }
 
+func TestUserGeneralParseErr(t *testing.T) {
+	var ug UserGeneral
+	ug.Parse("askdhfaskjas")
+	if ug.OwnerIdentifierIndicator != 0 {
+		t.Errorf("ug.OwnerIdentifierIndicator=%d", ug.OwnerIdentifierIndicator)
+	}
+}
+
 // TestMockUserGeneral creates a UserGeneral
 func TestMockUserGeneral(t *testing.T) {
 	ug := mockUserGeneral()

--- a/userPayeeEndorsement.go
+++ b/userPayeeEndorsement.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // The User Payee Endorsement Format Record is conditional, and contains a user controlled number of fields.  The
@@ -117,6 +118,10 @@ func NewUserPayeeEndorsement() *UserPayeeEndorsement {
 
 // Parse takes the input record string and parses the UserPayeeEndorsement values
 func (upe *UserPayeeEndorsement) Parse(record string) {
+	if utf8.RuneCountInString(record) < 335 {
+		return
+	}
+
 	// Character position 1-2, Always "68"
 	upe.recordType = "68"
 	// 03-03

--- a/userPayeeEndorsement_test.go
+++ b/userPayeeEndorsement_test.go
@@ -39,6 +39,14 @@ func mockUserPayeeEndorsement() *UserPayeeEndorsement {
 	return upe
 }
 
+func TestUserPayeeEndorsementParseErr(t *testing.T) {
+	var upe UserPayeeEndorsement
+	upe.Parse("asjsahfakja")
+	if upe.OwnerIdentifierIndicator != 0 {
+		t.Errorf("upe.OwnerIdentifierIndicator=%d", upe.OwnerIdentifierIndicator)
+	}
+}
+
 // TestMockUserPayeeEndorsement creates a UserPayeeEndorsement
 func TestMockUserPayeeEndorsement(t *testing.T) {
 	upe := mockUserPayeeEndorsement()


### PR DESCRIPTION
This PR just checks every Parse method for slice indexing as that's a common case for panics. 