### PR TITLE
Button for UI to select ICL file to parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ openapi-generator-cli-*.jar
 # fuzzing
 test/fuzz-reader/fuzzreader-fuzz.zip
 test/fuzz-reader/corpus/*.tar.gz
+
+# GoLand
+/.idea/*

--- a/cmd/webui/assets/index.html
+++ b/cmd/webui/assets/index.html
@@ -100,8 +100,15 @@
         </p>
       </header>
       <textarea id="jsoninput" name="jsoninput" cols="80" rows="40" placeholder="Paste your ICL file contents here..." required></textarea>
-      <button type="submit" onclick="json(jsoninput.value)">Parse ICL file</button>
+      <div id="buttons">
+        <button type="submit" onclick="json(jsoninput.value)">Parse ICL file</button>
+        <button type="submit" onclick="clearForms()">Clear Forms</button>
+      </div>
       <textarea id="jsonoutput" name="jsonoutput" cols="80" rows="40" readonly></textarea>
+      <div>
+        <label for="input-file">Specify a file:</label><br>
+        <input type="file" id="input-file">
+      </div>
     </form>
   </body>
   <script>
@@ -110,9 +117,42 @@
       jsonoutput.setSelectionRange(0,0)
       jsonoutput.focus()
     }
+
+    const clearForms = function() {
+      jsoninput.value = ""
+      jsonoutput.value = ""
+      document.getElementById('input-file').value = ''
+    }
     iclform.addEventListener('submit', (event) => {
       event.preventDefault();
       json(jsoninput.value)
     })
+
+    document.getElementById('input-file')
+            .addEventListener('change', parseFromFile)
+
+    function parseFromFile(event) {
+      const input = event.target
+      if ('files' in input && input.files.length > 0) {
+        placeFileContent(
+                document.getElementById('jsonoutput'),
+                input.files[0])
+      }
+    }
+
+    function placeFileContent(target, file) {
+      readFileContent(file).then(content => {
+        json(content)
+      }).catch(error => console.log(error))
+    }
+
+    function readFileContent(file) {
+      const reader = new FileReader()
+      return new Promise((resolve, reject) => {
+        reader.onload = event => resolve(event.target.result)
+        reader.onerror = error => reject(error)
+        reader.readAsText(file)
+      })
+    }
   </script>
 </html>


### PR DESCRIPTION
This PR introduces a web UI which can parse ICL files from Go->WASM cross-compiling of our library. It lets us host a tool/demo for the community. 

To run / dev locally run:
```
make build-webui && go run ./cmd/webui/
```
Then open http://localhost:8083/ in a browser. You can use [some of our test files](https://github.com/moov-io/imagecashletter/tree/master/test/testdata) as examples. 