### PR TITLE
writer: fix panic in image collation with empty data/analysis

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -259,13 +259,13 @@ func (w *Writer) writeCheckImageView(cd *CheckDetail) error {
 			if err := w.writeLine(&ivDetail); err != nil {
 				return err
 			}
-			if len(ivDataSlice) >= i {
+			if length := len(ivDataSlice); length > 0 && length >= i {
 				ivData := ivDataSlice[i]
 				if err := w.writeLine(&ivData); err != nil {
 					return err
 				}
 			}
-			if len(ivAnalysisSlice) >= i {
+			if length := len(ivAnalysisSlice); length > 0 && length >= i {
 				ivAnalysis := ivAnalysisSlice[i]
 				if err := w.writeLine(&ivAnalysis); err != nil {
 					return err


### PR DESCRIPTION
Not sure why this was just failing locally... 

```
--- FAIL: TestICLWrite_VariableLengthOption (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 21 [running]:
testing.tRunner.func1.1(0x13448a0, 0xc0000e6640)
	/usr/local/Cellar/go/1.15.3/libexec/src/testing/testing.go:1072 +0x30d
testing.tRunner.func1(0xc000082c00)
	/usr/local/Cellar/go/1.15.3/libexec/src/testing/testing.go:1075 +0x41a
panic(0x13448a0, 0xc0000e6640)
	/usr/local/Cellar/go/1.15.3/libexec/src/runtime/panic.go:969 +0x1b9
github.com/moov-io/imagecashletter.(*Writer).writeCheckImageView(0xc0000b68a0, 0xc000082f00, 0x0, 0x0)
	/Users/adam/code/src/github.com/moov-io/imagecashletter/writer.go:269 +0x9b8
github.com/moov-io/imagecashletter.(*Writer).writeCheckDetail(0xc0000b68a0, 0xc000094550, 0xc00015e000, 0x0)
	/Users/adam/code/src/github.com/moov-io/imagecashletter/writer.go:207 +0x12b
github.com/moov-io/imagecashletter.(*Writer).writeBundle(0xc0000b68a0, 0x0, 0x0, 0xc0000f4a00, 0xc0000aa118, 0x1, 0x1, 0x0, 0x0, 0x0, ...)
	/Users/adam/code/src/github.com/moov-io/imagecashletter/writer.go:181 +0x1e6
github.com/moov-io/imagecashletter.(*Writer).writeCashLetter(0xc0000b68a0, 0xc00015c1e0, 0xc00015c1f0, 0x0)
	/Users/adam/code/src/github.com/moov-io/imagecashletter/writer.go:159 +0x158
github.com/moov-io/imagecashletter.(*Writer).Write(0xc0000b68a0, 0xc00015c1e0, 0xc00010fd58, 0x2)
	/Users/adam/code/src/github.com/moov-io/imagecashletter/writer.go:132 +0xce
github.com/moov-io/imagecashletter.TestICLWrite_VariableLengthOption(0xc000082c00)
	/Users/adam/code/src/github.com/moov-io/imagecashletter/writer_test.go:268 +0x456
testing.tRunner(0xc000082c00, 0x13963d8)
	/usr/local/Cellar/go/1.15.3/libexec/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
	/usr/local/Cellar/go/1.15.3/libexec/src/testing/testing.go:1168 +0x2b3
FAIL	github.com/moov-io/imagecashletter	0.070s
```