### PR TITLE
Modify ReturnDetail.ReturnNotificationIndicator to be a string

### DIFF
--- a/examples/imagecashletter-write/main.go
+++ b/examples/imagecashletter-write/main.go
@@ -211,7 +211,7 @@ func main() {
 	rd.ForwardBundleDate = time.Now()
 	rd.EceInstitutionItemSequenceNumber = "1              "
 	rd.ExternalProcessingCode = ""
-	rd.ReturnNotificationIndicator = 2
+	rd.ReturnNotificationIndicator = "2"
 	rd.ArchiveTypeIndicator = "B"
 	rd.TimesReturned = 0
 
@@ -355,7 +355,7 @@ func main() {
 	rdTwo.ForwardBundleDate = time.Now()
 	rdTwo.EceInstitutionItemSequenceNumber = "1              "
 	rdTwo.ExternalProcessingCode = ""
-	rdTwo.ReturnNotificationIndicator = 2
+	rdTwo.ReturnNotificationIndicator = "2"
 	rdTwo.ArchiveTypeIndicator = "B"
 	rdTwo.TimesReturned = 0
 

--- a/returnDetail.go
+++ b/returnDetail.go
@@ -106,7 +106,7 @@ type ReturnDetail struct {
 	// Values:
 	// 1: Preliminary notification
 	// 2: Final notification
-	ReturnNotificationIndicator int `json:"returnNotificationIndicator"`
+	ReturnNotificationIndicator string `json:"returnNotificationIndicator"`
 	// ArchiveTypeIndicator is a code that indicates the type of archive that supports this CheckDetail.
 	// Access method, availability and time-frames shall be defined by clearing arrangements.
 	// Values:
@@ -204,7 +204,7 @@ func (rd *ReturnDetail) Parse(record string) {
 	// 69-69
 	rd.ExternalProcessingCode = rd.parseStringField(record[68:69])
 	// 70-70
-	rd.ReturnNotificationIndicator = rd.parseNumField(record[69:70])
+	rd.ReturnNotificationIndicator = rd.parseStringField(record[69:70])
 	// 71-71
 	rd.ArchiveTypeIndicator = rd.parseStringField(record[70:71])
 	// 72-72
@@ -216,13 +216,20 @@ func (rd *ReturnDetail) Parse(record string) {
 func (rd *ReturnDetail) UnmarshalJSON(data []byte) error {
 	type Alias ReturnDetail
 	aux := struct {
+		// json.RawMessage is used here to allow library to still parse json files that stored
+		// RNI in an int. json.Number could also be used, but X937 standard doesn't specify a
+		// type for the RNI, so, RawMessage provides flexibility to handle non-numeric values
+		ReturnNotificationIndicator json.RawMessage `json:"returnNotificationIndicator"`
 		*Alias
 	}{
-		(*Alias)(rd),
+		Alias: (*Alias)(rd),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
+	// removes the quotes if its text, does nothing if its numeric
+	trimmed := strings.Trim(string(aux.ReturnNotificationIndicator),"\"")
+	rd.ReturnNotificationIndicator = trimmed
 	rd.setRecordType()
 	return nil
 }
@@ -269,17 +276,17 @@ func (rd *ReturnDetail) Validate() error {
 			return &FieldError{FieldName: "DocumentationTypeIndicator", Value: rd.DocumentationTypeIndicator, Msg: err.Error()}
 		}
 	}
-	if rd.ReturnNotificationIndicatorField() != "" {
+	if rd.ReturnNotificationIndicator != "" {
 		if err := rd.isReturnNotificationIndicator(rd.ReturnNotificationIndicator); err != nil {
 			return &FieldError{FieldName: "ReturnNotificationIndicator", Value: rd.ReturnNotificationIndicatorField(), Msg: err.Error()}
 		}
 	}
-	if rd.ArchiveTypeIndicatorField() != "" {
+	if rd.ArchiveTypeIndicator != "" {
 		if err := rd.isArchiveTypeIndicator(rd.ArchiveTypeIndicator); err != nil {
 			return &FieldError{FieldName: "ArchiveTypeIndicator", Value: rd.ArchiveTypeIndicatorField(), Msg: err.Error()}
 		}
 	}
-	if rd.TimesReturnedField() != "" {
+	if rd.TimesReturnedField() != " " && rd.TimesReturnedField() != "" {
 		if err := rd.isTimesReturned(rd.TimesReturned); err != nil {
 			return &FieldError{FieldName: "TimesReturned", Value: rd.TimesReturnedField(), Msg: err.Error()}
 		}
@@ -384,7 +391,7 @@ func (rd *ReturnDetail) ExternalProcessingCodeField() string {
 
 // ReturnNotificationIndicatorField gets a string of the ReturnNotificationIndicator field
 func (rd *ReturnDetail) ReturnNotificationIndicatorField() string {
-	return rd.numericField(rd.ReturnNotificationIndicator, 1)
+	return rd.alphaField(rd.ReturnNotificationIndicator, 1)
 }
 
 // ArchiveTypeIndicatorField gets the ArchiveTypeIndicator field

--- a/returnDetail_test.go
+++ b/returnDetail_test.go
@@ -24,7 +24,7 @@ func mockReturnDetail() *ReturnDetail {
 	rd.ForwardBundleDate = time.Now()
 	rd.EceInstitutionItemSequenceNumber = "1              "
 	rd.ExternalProcessingCode = ""
-	rd.ReturnNotificationIndicator = 2
+	rd.ReturnNotificationIndicator = "2"
 	rd.ArchiveTypeIndicator = "B"
 	rd.TimesReturned = 0
 	return rd
@@ -74,7 +74,7 @@ func TestMockReturnDetail(t *testing.T) {
 	if rd.ExternalProcessingCode != "" {
 		t.Error("ExternalProcessingCode does not validate")
 	}
-	if rd.ReturnNotificationIndicator != 2 {
+	if rd.ReturnNotificationIndicator != "2" {
 		t.Error("ReturnNotificationIndicator does not validate")
 	}
 	if rd.ArchiveTypeIndicator != "B" {
@@ -225,7 +225,7 @@ func TestRDDocumentationTypeIndicatorZ(t *testing.T) {
 // TestRDReturnNotificationIndicator validation
 func TestRDReturnNotificationIndicator(t *testing.T) {
 	rd := mockReturnDetail()
-	rd.ReturnNotificationIndicator = 0
+	rd.ReturnNotificationIndicator = "0"
 	if err := rd.Validate(); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "ReturnNotificationIndicator" {
@@ -243,9 +243,9 @@ func TestRDArchiveTypeIndicator(t *testing.T) {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "ArchiveTypeIndicator" {
 				t.Errorf("%T: %s", err, err)
-			}
-		}
-	}
+		    }
+	    }
+    }
 }
 
 // TestRDTimesReturned validation

--- a/validators.go
+++ b/validators.go
@@ -676,13 +676,13 @@ func (v *validator) isImageViewAnalysisValid(code string) error {
 // Returns
 
 // isReturnNotificationIndicator ensures ReturnNotificationIndicator of ReturnDetail is valid
-func (v *validator) isReturnNotificationIndicator(code int) error {
+func (v *validator) isReturnNotificationIndicator(code string) error {
 	switch code {
 	case
 		// Preliminary notification
-		1,
+		"1",
 		// Final notification
-		2:
+		"2":
 		return nil
 	}
 	return errors.New(msgInvalid)


### PR DESCRIPTION
`ReturnDetail.ReturnNotificationIndicator` was being stored as an `int` which causes returns with a RNI value of `" "` to fail to parse as `int` can't capture that the field was empty, not a value of `0`. PR changes RNI to an alpha field and introduces a backwards-compatibility modification to the JSON parser so previously saved .json representations can still be unmarshalled without error.