### PR TITLE
Fix a few values overwritten by defaults

### DIFF
--- a/cashLetterControl.go
+++ b/cashLetterControl.go
@@ -64,9 +64,8 @@ func (clc *CashLetterControl) setRecordType() {
 	}
 
 	clc.recordType = "90"
-	now := time.Now()
-	if now.After(clc.SettlementDate) {
-		clc.SettlementDate = now
+	if clc.SettlementDate.IsZero() {
+		clc.SettlementDate = time.Now()
 	}
 	clc.reserved = "              "
 }

--- a/cashLetterControl.go
+++ b/cashLetterControl.go
@@ -64,7 +64,10 @@ func (clc *CashLetterControl) setRecordType() {
 	}
 
 	clc.recordType = "90"
-	clc.SettlementDate = time.Now()
+	now := time.Now()
+	if now.After(clc.SettlementDate) {
+		clc.SettlementDate = now
+	}
 	clc.reserved = "              "
 }
 

--- a/file.go
+++ b/file.go
@@ -261,9 +261,8 @@ func (f *File) Create() error {
 	fc.TotalRecordCount = fileTotalRecordCount
 	fc.TotalItemCount = fileTotalItemCount
 	fc.FileTotalAmount = fileTotalAmount
-	// May need to pass in a FC for these values
-	fc.ImmediateOriginContactName = ""
-	fc.ImmediateOriginContactPhoneNumber = ""
+	fc.ImmediateOriginContactName = f.Control.ImmediateOriginContactName
+	fc.ImmediateOriginContactPhoneNumber = f.Control.ImmediateOriginContactPhoneNumber
 	fc.CreditTotalIndicator = creditIndicator
 	f.Control = fc
 	return nil

--- a/fileHeader.go
+++ b/fileHeader.go
@@ -106,7 +106,7 @@ func (fh *FileHeader) setRecordType() {
 		return
 	}
 	fh.recordType = "01"
-	fh.StandardLevel = "35"
+	// fh.StandardLevel = "35"
 }
 
 // Parse takes the input record string and parses the FileHeader values

--- a/fileHeader.go
+++ b/fileHeader.go
@@ -98,6 +98,7 @@ type FileHeader struct {
 func NewFileHeader() FileHeader {
 	fh := FileHeader{}
 	fh.setRecordType()
+	fh.StandardLevel = "35"
 	return fh
 }
 
@@ -106,7 +107,6 @@ func (fh *FileHeader) setRecordType() {
 		return
 	}
 	fh.recordType = "01"
-	// fh.StandardLevel = "35"
 }
 
 // Parse takes the input record string and parses the FileHeader values


### PR DESCRIPTION
Fix a few instances where a value passed to the create file endpoint is overwritten by defaults:

- standardLevel
- settlementDate
- immediateOriginContactName
- immediateOriginContactPhoneNumber

I feel like I may be missing something, are there cases where these properties don't exist yet on the object and the aggressive defaults are warranted?