### PR TITLE
add version increment check to release script

### DIFF
--- a/tagged-release.sh
+++ b/tagged-release.sh
@@ -1,6 +1,44 @@
-#!/bin/sh
+#!/bin/bash
 
 [ $# -eq 0 ] && { echo "Usage: $0 version_tag"; exit 1; }
+
+# make sure this is a new tag
+if git show-ref --tags | grep -q "$1"; then
+  echo "$1 already exists!"
+  exit
+fi
+
+# aborts if the git command fails
+if ! current=$(git describe --tags --abbrev=0); then
+    exit 1
+fi
+parts=( $( echo "$current" | grep -o -E '[0-9]+') )
+major=${parts[0]}
+minor=${parts[1]}
+bug=${parts[2]}
+
+newMajorVersion=v$((major+1)).0.0
+newMinorVersion=v$major.$((minor+1)).0
+newBugVersion=v$major.$minor.$((bug+1))
+
+if [[ "$newVersionTag" == "$newMajorVersion" ]]; then
+  echo "releasing new major version $newVersionTag (currently on $current)"
+elif [[ "$newVersionTag" == "$newMinorVersion" ]]; then
+  echo "releasing new minor version $newVersionTag (currently on $current)"
+elif [[ "$newVersionTag" == "$newBugVersion" ]]; then
+  echo "releasing new bug fix $newVersionTag (currently on $current)"
+else
+  echo cannot increment version from "$current" to "$newVersionTag"
+  exit 1
+fi
+
+read -p "Do you want to continue? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo "aborting release"
+    exit 0
+fi
 
 # releases should be created from master branch
 if [ "$(git branch --show-current)" != "master" ]
@@ -9,9 +47,8 @@ then
     git checkout master > /dev/null 2>&1
 fi
 
-status=$(git status --porcelain)
-
 # only 2 files should be changed
+status=$(git status --porcelain)
 if [ "$(echo "$status" | wc -l)" -ne 2 ]
 then
   echo "Only version.go and CHANGELOG.md should be updated!"
@@ -24,12 +61,6 @@ elif ! echo "$status" | grep -q "CHANGELOG.md" && ! echo "$status" | grep -q "ve
 then
     echo "version.go and changelog.md must be updated to proceed"
     exit
-fi
-
-# make sure this is a new tag
-if git show-ref --tags | grep -q "$1"; then
-  echo "$1 already exists!"
-  exit
 fi
 
 firstLine=$(head -n 1 CHANGELOG.md)


### PR DESCRIPTION
This addition to tagged-release.sh ensures the version number is being incremented correctly for a new release.