### PR TITLE
Make ReturnDetailAddendumB.PayorBankBusinessDate an optional value

### DIFF
--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -89,6 +89,32 @@ func (rdAddendumB *ReturnDetailAddendumB) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (rdAddendumB ReturnDetailAddendumB) MarshalJSON() ([]byte, error) {
+	type Alias ReturnDetailAddendumB
+	if rdAddendumB.PayorBankBusinessDate.IsZero() {
+		// put the empty string in
+		return json.Marshal(&struct{
+			*Alias
+			PayorBankBusinessDate string `json:"payorBankBusinessDate"`
+		}{
+			Alias: (*Alias)(&rdAddendumB),
+			PayorBankBusinessDate: "",
+		})
+	} else {
+		// necessary to avoid infinite recursion
+		return json.Marshal(&struct{
+			*Alias
+			PayorBankBusinessDate time.Time `json:"payorBankBusinessDate"`
+		}{
+			Alias: (*Alias)(&rdAddendumB),
+			PayorBankBusinessDate: rdAddendumB.PayorBankBusinessDate,
+		})
+	}
+}
+
+
+
+
 // String writes the ReturnDetailAddendumB struct to a string.
 func (rdAddendumB *ReturnDetailAddendumB) String() string {
 	var buf strings.Builder

--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -166,11 +166,7 @@ func (rdAddendumB *ReturnDetailAddendumB) fieldInclusion() error {
 			Value: rdAddendumB.PayorBankSequenceNumber,
 			Msg:   msgFieldInclusion + ", did you use ReturnDetailAddendumB()?"}
 	}
-	//if rdAddendumB.PayorBankBusinessDate.IsZero() {
-	//	return &FieldError{FieldName: "PayorBankBusinessDate",
-	//		Value: rdAddendumB.PayorBankBusinessDate.String(),
-	//		Msg:   msgFieldInclusion + ", did you use ReturnDetailAddendumB()?"}
-	//}
+
 	return nil
 }
 

--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -95,7 +95,7 @@ func (rdAddendumB *ReturnDetailAddendumB) UnmarshalJSON(data []byte) error {
 			return dateErr
 		}
 	} else if !rdAddendumB.PayorBankBusinessDate.IsZero() {
-		// check if the current value is the zero value and setting it to
+		// checking if the current value is the zero value and setting it to
 		// the zero value if it isn't
 		rdAddendumB.PayorBankBusinessDate = time.Time{}
 	}

--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -106,7 +106,7 @@ func (rdAddendumB *ReturnDetailAddendumB) UnmarshalJSON(data []byte) error {
 func (rdAddendumB ReturnDetailAddendumB) MarshalJSON() ([]byte, error) {
 	type Alias ReturnDetailAddendumB
 	if rdAddendumB.PayorBankBusinessDate.IsZero() {
-		// put the empty string in
+		// put the empty string in instead of marshalling the zero value
 		return json.Marshal(&struct{
 			*Alias
 			PayorBankBusinessDate string `json:"payorBankBusinessDate"`

--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -88,16 +88,18 @@ func (rdAddendumB *ReturnDetailAddendumB) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
+	// The spec calls for this field to be formatted as YYYYMMDD, but we should handle
+	// RFC3339 as well for convenience. Default to empty time.Time{} if no date was passed in.
+	rdAddendumB.PayorBankBusinessDate = time.Time{}
 	if aux.PayorBankBusinessDate != "" {
-		if dateErr := rdAddendumB.PayorBankBusinessDate.UnmarshalJSON(
-			[]byte("\""+aux.PayorBankBusinessDate+"\""),
-		); dateErr != nil {
-			return dateErr
+		parsed, err := time.Parse(time.RFC3339, aux.PayorBankBusinessDate)
+		if err != nil {
+			parsed, err = time.Parse("20060102", aux.PayorBankBusinessDate)
+			if err != nil {
+				return err
+			}
 		}
-	} else if !rdAddendumB.PayorBankBusinessDate.IsZero() {
-		// checking if the current value is the zero value and setting it to
-		// the zero value if it isn't
-		rdAddendumB.PayorBankBusinessDate = time.Time{}
+		rdAddendumB.PayorBankBusinessDate = parsed
 	}
 	rdAddendumB.setRecordType()
 	return nil

--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -134,11 +134,11 @@ func (rdAddendumB *ReturnDetailAddendumB) fieldInclusion() error {
 			Value: rdAddendumB.PayorBankSequenceNumber,
 			Msg:   msgFieldInclusion + ", did you use ReturnDetailAddendumB()?"}
 	}
-	if rdAddendumB.PayorBankBusinessDate.IsZero() {
-		return &FieldError{FieldName: "PayorBankBusinessDate",
-			Value: rdAddendumB.PayorBankBusinessDate.String(),
-			Msg:   msgFieldInclusion + ", did you use ReturnDetailAddendumB()?"}
-	}
+	//if rdAddendumB.PayorBankBusinessDate.IsZero() {
+	//	return &FieldError{FieldName: "PayorBankBusinessDate",
+	//		Value: rdAddendumB.PayorBankBusinessDate.String(),
+	//		Msg:   msgFieldInclusion + ", did you use ReturnDetailAddendumB()?"}
+	//}
 	return nil
 }
 
@@ -159,7 +159,11 @@ func (rdAddendumB *ReturnDetailAddendumB) PayorBankSequenceNumberField() string 
 
 // PayorBankBusinessDateField gets the PayorBankBusinessDate in YYYYMMDD format
 func (rdAddendumB *ReturnDetailAddendumB) PayorBankBusinessDateField() string {
-	return rdAddendumB.formatYYYYMMDDDate(rdAddendumB.PayorBankBusinessDate)
+	if rdAddendumB.PayorBankBusinessDate.IsZero() {
+		return rdAddendumB.alphaField("",8)
+	} else {
+		return rdAddendumB.formatYYYYMMDDDate(rdAddendumB.PayorBankBusinessDate)
+	}
 }
 
 // PayorAccountNameField gets the PayorAccountName field

--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -114,14 +114,14 @@ func (rdAddendumB ReturnDetailAddendumB) MarshalJSON() ([]byte, error) {
 			Alias: (*Alias)(&rdAddendumB),
 			PayorBankBusinessDate: "",
 		})
-	} else {
-		// necessary to still use the alias to avoid infinite recursion
-		return json.Marshal(&struct{
-			*Alias
-		}{
-			Alias: (*Alias)(&rdAddendumB),
-		})
 	}
+
+	// necessary to still use the alias to avoid infinite recursion
+	return json.Marshal(&struct{
+		*Alias
+	}{
+		Alias: (*Alias)(&rdAddendumB),
+	})
 }
 
 

--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -79,11 +79,17 @@ func (rdAddendumB *ReturnDetailAddendumB) UnmarshalJSON(data []byte) error {
 	type Alias ReturnDetailAddendumB
 	aux := struct {
 		*Alias
+		PayorBankBusinessDate string `json:"payorBankBusinessDate"`
 	}{
-		(*Alias)(rdAddendumB),
+		Alias: (*Alias)(rdAddendumB),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
+	}
+	if aux.PayorBankBusinessDate != "" {
+		if dateErr := rdAddendumB.UnmarshalJSON([]byte("\""+aux.PayorBankBusinessDate+"\"")); dateErr != nil {
+			return dateErr
+		}
 	}
 	rdAddendumB.setRecordType()
 	return nil

--- a/returnDetailAddendumB.go
+++ b/returnDetailAddendumB.go
@@ -195,9 +195,9 @@ func (rdAddendumB *ReturnDetailAddendumB) PayorBankSequenceNumberField() string 
 func (rdAddendumB *ReturnDetailAddendumB) PayorBankBusinessDateField() string {
 	if rdAddendumB.PayorBankBusinessDate.IsZero() {
 		return rdAddendumB.alphaField("",8)
-	} else {
-		return rdAddendumB.formatYYYYMMDDDate(rdAddendumB.PayorBankBusinessDate)
 	}
+
+	return rdAddendumB.formatYYYYMMDDDate(rdAddendumB.PayorBankBusinessDate)
 }
 
 // PayorAccountNameField gets the PayorAccountName field

--- a/returnDetailAddendumB_test.go
+++ b/returnDetailAddendumB_test.go
@@ -5,6 +5,7 @@
 package imagecashletter
 
 import (
+	"encoding/json"
 	"log"
 	"strings"
 	"testing"
@@ -112,6 +113,50 @@ func testRDAddendumBString(t testing.TB) {
 
 	if record.String() != line {
 		t.Errorf("Strings do not match")
+	}
+}
+
+// TestParseAddendumBJSON tests parsing a known ReturnDetailAddendumB
+func TestParseAddendumBJSON(t *testing.T) {
+	addB := ReturnDetailAddendumB{}
+	var testBusinessDateJSON =`{
+		"id": "",
+		"payorBankName": "",
+		"auxiliaryOnUs": "",
+		"payorBankSequenceNumber": "3713365076",
+		"payorAccountName": "",
+		"payorBankBusinessDate": "2021-01-21T00:00:00Z"
+}`
+	if err := json.Unmarshal([]byte(testBusinessDateJSON), &addB); err != nil {
+		t.Errorf("Unable to unmarshal ReturnDetailAddendumB JSON: %v", err)
+	}
+	if addB.PayorBankSequenceNumber != "3713365076" {
+		t.Errorf("PayorBankSequenceNumber Expected '3713365076' got: %v", addB.PayorBankSequenceNumber)
+	}
+	parsedTime, timeParseErr := time.Parse(time.RFC3339,"2021-01-21T00:00:00Z")
+	if timeParseErr != nil {
+		t.Errorf("Unable to parse test time: %v", timeParseErr)
+	}
+	if !addB.PayorBankBusinessDate.Equal(parsedTime) {
+		t.Errorf("PayorBankBusinessDate Expected '2021-01-21T00:00:00Z' got: %v", addB.PayorBankBusinessDate)
+	}
+
+	var testNoBusinessDateJSON =`{
+		"id": "",
+		"payorBankName": "",
+		"auxiliaryOnUs": "",
+		"payorBankSequenceNumber": "3713365088",
+		"payorAccountName": "",
+		"payorBankBusinessDate": ""
+}`
+	if err := json.Unmarshal([]byte(testNoBusinessDateJSON), &addB); err != nil {
+		t.Errorf("Unable to unmarshal ReturnDetailAddendumB JSON: %v", err)
+	}
+	if addB.PayorBankSequenceNumber != "3713365088" {
+		t.Errorf("PayorBankSequenceNumber Expected '3713365088' got: %v", addB.PayorBankSequenceNumber)
+	}
+	if !addB.PayorBankBusinessDate.IsZero() {
+		t.Errorf("PayorBankBusinessDate Expected zero-date got: %v", addB.PayorBankBusinessDate)
 	}
 }
 

--- a/returnDetailAddendumB_test.go
+++ b/returnDetailAddendumB_test.go
@@ -140,6 +140,13 @@ func TestParseAddendumBJSON(t *testing.T) {
 	if !addB.PayorBankBusinessDate.Equal(parsedTime) {
 		t.Errorf("PayorBankBusinessDate Expected '2021-01-21T00:00:00Z' got: %v", addB.PayorBankBusinessDate)
 	}
+	marshalledDate, marshalDateErr := json.Marshal(addB)
+	if marshalDateErr != nil {
+		t.Errorf("Unable to marshal ReturnDetailAddendumB to JSON: %v", marshalDateErr)
+	}
+	if !strings.Contains(string(marshalledDate),"2021-01-21T00:00:00Z") {
+		t.Errorf("ReturnDetailAddendumB failed to marshal time.Time value")
+	}
 
 	var testNoBusinessDateJSON =`{
 		"id": "",
@@ -157,6 +164,14 @@ func TestParseAddendumBJSON(t *testing.T) {
 	}
 	if !addB.PayorBankBusinessDate.IsZero() {
 		t.Errorf("PayorBankBusinessDate Expected zero-date got: %v", addB.PayorBankBusinessDate)
+	}
+
+	marshalled, marshalErr := json.Marshal(addB)
+	if marshalErr != nil {
+		t.Errorf("Unable to marshal ReturnDetailAddendumB to JSON: %v", marshalErr)
+	}
+	if strings.Contains(string(marshalled),"0001-01-01") {
+		t.Errorf("ReturnDetailAddendumB marshalled zero time.Time value")
 	}
 }
 


### PR DESCRIPTION
PayorBankBusinessDate is currently required, PR removes this requirement. Supporting this change, additional changes are made to how PayorBankBusinessDate is handled when marshalling/unmarshalling ReturnDetailAddendumB to/from JSON and how zero-values for PayorBankBusinessDate are handled in PayorBankBusinessDateField()