### PR TITLE
Only fail validation of cash letter control for `settlementDate` field if it is not a return type

### DIFF
--- a/cashLetterControl.go
+++ b/cashLetterControl.go
@@ -128,8 +128,8 @@ func (clc *CashLetterControl) String() string {
 
 // Validate performs imagecashletter format rule checks on the record and returns an error if not Validated
 // The first error encountered is returned and stops the parsing.
-func (clc *CashLetterControl) Validate() error {
-	if err := clc.fieldInclusion(); err != nil {
+func (clc *CashLetterControl) Validate(collectionTypeIndicator string) error {
+	if err := clc.fieldInclusion(collectionTypeIndicator); err != nil {
 		return err
 	}
 	if clc.recordType != "90" {
@@ -149,7 +149,7 @@ func (clc *CashLetterControl) Validate() error {
 
 // fieldInclusion validate mandatory fields are not default values. If fields are
 // invalid the Electronic Exchange will be returned.
-func (clc *CashLetterControl) fieldInclusion() error {
+func (clc *CashLetterControl) fieldInclusion(collectionTypeIndicator string) error {
 	if clc.recordType == "" {
 		return &FieldError{FieldName: "recordType",
 			Value: clc.recordType,
@@ -165,7 +165,8 @@ func (clc *CashLetterControl) fieldInclusion() error {
 			Value: clc.CashLetterTotalAmountField(),
 			Msg:   msgFieldInclusion + ", did you use CashLetterControl()?"}
 	}
-	if clc.SettlementDate.IsZero() {
+	// If the type of the cash letter control is `Return`, we do not require to have this field present.
+	if clc.SettlementDate.IsZero() && collectionTypeIndicator != "03" {
 		return &FieldError{FieldName: "SettlementDate",
 			Value: clc.SettlementDate.String(),
 			Msg:   msgFieldInclusion + ", did you use CashLetterControl()?"}

--- a/cashLetterControl.go
+++ b/cashLetterControl.go
@@ -166,7 +166,7 @@ func (clc *CashLetterControl) fieldInclusion(collectionTypeIndicator string) err
 			Msg:   msgFieldInclusion + ", did you use CashLetterControl()?"}
 	}
 	// If the type of the cash letter control is `Return`, we do not require to have this field present.
-	if clc.SettlementDate.IsZero() && collectionTypeIndicator != "03" {
+	if clc.SettlementDate.IsZero() && !isReturnCollectionType(collectionTypeIndicator) {
 		return &FieldError{FieldName: "SettlementDate",
 			Value: clc.SettlementDate.String(),
 			Msg:   msgFieldInclusion + ", did you use CashLetterControl()?"}
@@ -212,4 +212,11 @@ func (clc *CashLetterControl) CreditTotalIndicatorField() string {
 // reservedField gets reserved - blank space
 func (clc *CashLetterControl) reservedField() string {
 	return clc.alphaField(clc.reserved, 14)
+}
+
+func isReturnCollectionType(code string) bool {
+	if code == "03" || code == "04" || code == "05" || code == "06" {
+		return true
+	}
+	return false
 }

--- a/cashLetterControl_test.go
+++ b/cashLetterControl_test.go
@@ -27,7 +27,7 @@ func mockCashLetterControl() *CashLetterControl {
 // TestMockCashLetterControl creates a CashLetterControl
 func TestMockCashLetterControl(t *testing.T) {
 	clc := mockCashLetterControl()
-	if err := clc.Validate(); err != nil {
+	if err := clc.Validate("01"); err != nil {
 		t.Error("mockCashLetterControl does not validate and will break other tests: ", err)
 	}
 	if clc.recordType != "90" {
@@ -60,7 +60,7 @@ func TestParseCashLetterControl(t *testing.T) {
 	r.line = line
 	clh := mockCashLetterHeader()
 	r.addCurrentCashLetter(NewCashLetter(clh))
-	err := r.parseCashLetterControl()
+	err := r.parseCashLetterControl("03")
 	if err != nil {
 		t.Errorf("%T: %s", err, err)
 		log.Fatal(err)
@@ -103,7 +103,7 @@ func testCLCString(t testing.TB) {
 	r.line = line
 	clh := mockCashLetterHeader()
 	r.addCurrentCashLetter(NewCashLetter(clh))
-	err := r.parseCashLetterControl()
+	err := r.parseCashLetterControl("01")
 	if err != nil {
 		t.Errorf("%T: %s", err, err)
 		log.Fatal(err)
@@ -131,7 +131,7 @@ func BenchmarkCLCString(b *testing.B) {
 func TestCLCRecordType(t *testing.T) {
 	clc := mockCashLetterControl()
 	clc.recordType = "00"
-	if err := clc.Validate(); err != nil {
+	if err := clc.Validate("01"); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "recordType" {
 				t.Errorf("%T: %s", err, err)
@@ -144,7 +144,7 @@ func TestCLCRecordType(t *testing.T) {
 func TestECEInstitutionName(t *testing.T) {
 	clc := mockCashLetterControl()
 	clc.ECEInstitutionName = "®©"
-	if err := clc.Validate(); err != nil {
+	if err := clc.Validate("01"); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "ECEInstitutionName" {
 				t.Errorf("%T: %s", err, err)
@@ -157,7 +157,7 @@ func TestECEInstitutionName(t *testing.T) {
 func TestCLCCreditTotalIndicator(t *testing.T) {
 	clc := mockCashLetterControl()
 	clc.CreditTotalIndicator = 9
-	if err := clc.Validate(); err != nil {
+	if err := clc.Validate("01"); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "CreditTotalIndicator" {
 				t.Errorf("%T: %s", err, err)
@@ -170,7 +170,7 @@ func TestCLCCreditTotalIndicator(t *testing.T) {
 func TestCLCFieldInclusionRecordType(t *testing.T) {
 	clc := mockCashLetterControl()
 	clc.recordType = ""
-	if err := clc.Validate(); err != nil {
+	if err := clc.Validate("01"); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "recordType" {
 				t.Errorf("%T: %s", err, err)
@@ -183,7 +183,7 @@ func TestCLCFieldInclusionRecordType(t *testing.T) {
 func TestFieldInclusionCashLetterItemsCount(t *testing.T) {
 	clc := mockCashLetterControl()
 	clc.CashLetterItemsCount = 0
-	if err := clc.Validate(); err != nil {
+	if err := clc.Validate("01"); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "CashLetterItemsCount" {
 				t.Errorf("%T: %s", err, err)
@@ -196,7 +196,7 @@ func TestFieldInclusionCashLetterItemsCount(t *testing.T) {
 func TestFieldInclusionCashLetterTotalAmount(t *testing.T) {
 	clc := mockCashLetterControl()
 	clc.CashLetterTotalAmount = 0
-	if err := clc.Validate(); err != nil {
+	if err := clc.Validate("01"); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "CashLetterTotalAmount" {
 				t.Errorf("%T: %s", err, err)
@@ -209,7 +209,7 @@ func TestFieldInclusionCashLetterTotalAmount(t *testing.T) {
 func TestFieldInclusionRecordTypeSettlementDate(t *testing.T) {
 	clc := mockCashLetterControl()
 	clc.SettlementDate = time.Time{}
-	if err := clc.Validate(); err != nil {
+	if err := clc.Validate("01"); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "SettlementDate" {
 				t.Errorf("%T: %s", err, err)

--- a/go.sum
+++ b/go.sum
@@ -1146,6 +1146,7 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=


### PR DESCRIPTION
Here is the [original discussion](https://github.com/moov-io/imagecashletter/issues/107#issuecomment-861919674) on this matter.

According to different specs, the `SettlementDate` is a conditional field. Currently, the parser requires this field to exist. Having this field present for Return bundles does not make sense hence why they are defined to be conditional.

There were two approaches to take:
1) To remove this check completely.
2) To not have it required for Return documents which are indicated by CollectionTypeIndicator. 

I went with the second approach.

<img width="1219" alt="Screen Shot 2021-07-06 at 9 47 08 PM" src="https://user-images.githubusercontent.com/3458619/124701649-cb7e0000-dea3-11eb-952a-d67dbf2a9727.png">
