### PR TITLE
Fix index-out-of-range in cashLetter

### DIFF
--- a/cashLetter.go
+++ b/cashLetter.go
@@ -209,7 +209,7 @@ func (cl *CashLetter) build() error {
 
 			for x := range rd.ReturnDetailAddendumD {
 				rd.ReturnDetailAddendumD[x].SetEndorsingBankItemSequenceNumber(rdSequenceNumber)
-				rd.ReturnDetailAddendumA[x].RecordNumber = rdAddendumDRecordNumber
+				rd.ReturnDetailAddendumD[x].RecordNumber = rdAddendumDRecordNumber
 				rdAddendumDRecordNumber++
 				if rdAddendumDRecordNumber > 99 {
 					rdAddendumDRecordNumber = 1


### PR DESCRIPTION
This fixes an index-out-of-range error in cashLetter, as well as incorrect results.
When looping through addendumD in a return, it was referencing addendumA rather than addendumD.