### PR TITLE
Fixed testFileIndicator -> testIndicator in swagger doc

### DIFF
--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -5919,7 +5919,7 @@ components:
       - immediateOrigin
       - resendIndicator
       - standardLevel
-      - testFileIndicator
+      - testIndicator
     ICLFileControl:
       example:
         cashLetterCount: 1


### PR DESCRIPTION
testFileIndicator is the wrong name in the swagger.yaml, testIndicator is used there.
Fixes the required (*) indicator in the swagger UI (doc)