### PR TITLE
credit: fix validation of ECEInstitutionItemSequenceNumber

### DIFF
--- a/credit.go
+++ b/credit.go
@@ -162,8 +162,10 @@ func (cr *Credit) Validate() error {
 			return &FieldError{FieldName: "DocumentationTypeIndicator", Value: cr.DocumentationTypeIndicator, Msg: msgInvalid}
 		}
 	}
-	if cr.ECEInstitutionItemSequenceNumberField() != "               " {
-		return &FieldError{FieldName: "ECEInstitutionItemSequenceNumber", Value: cr.ECEInstitutionItemSequenceNumber, Msg: msgInvalid}
+	if cr.ECEInstitutionItemSequenceNumber != "" {
+		if err := cr.isNumeric(cr.ECEInstitutionItemSequenceNumber); err != nil {
+			return &FieldError{FieldName: "ECEInstitutionItemSequenceNumber", Value: cr.ECEInstitutionItemSequenceNumber, Msg: msgInvalid}
+		}
 	}
 	if err := cr.isNumeric(cr.PayorBankRoutingNumber); err != nil {
 		return &FieldError{FieldName: "PayorBankRoutingNumber",


### PR DESCRIPTION
The validation logic for ECEInstitutionItemSequenceNumber was based on a misinterpretation of a bank-specific format. This update makes the `Credit` record type work for a wider variety of formats.