### PR TITLE
cashLetterControl: settlement date should not be mandatory

### DIFF
--- a/cashLetter.go
+++ b/cashLetter.go
@@ -106,7 +106,7 @@ func (cl *CashLetter) Validate() error {
 		}
 	}
 
-	if err := cl.CashLetterControl.Validate(cl.CashLetterHeader.CollectionTypeIndicator); err != nil {
+	if err := cl.CashLetterControl.Validate(); err != nil {
 		return err
 	}
 

--- a/cashLetterControl.go
+++ b/cashLetterControl.go
@@ -128,8 +128,8 @@ func (clc *CashLetterControl) String() string {
 
 // Validate performs imagecashletter format rule checks on the record and returns an error if not Validated
 // The first error encountered is returned and stops the parsing.
-func (clc *CashLetterControl) Validate(collectionTypeIndicator string) error {
-	if err := clc.fieldInclusion(collectionTypeIndicator); err != nil {
+func (clc *CashLetterControl) Validate() error {
+	if err := clc.fieldInclusion(); err != nil {
 		return err
 	}
 	if clc.recordType != "90" {
@@ -149,7 +149,7 @@ func (clc *CashLetterControl) Validate(collectionTypeIndicator string) error {
 
 // fieldInclusion validate mandatory fields are not default values. If fields are
 // invalid the Electronic Exchange will be returned.
-func (clc *CashLetterControl) fieldInclusion(collectionTypeIndicator string) error {
+func (clc *CashLetterControl) fieldInclusion() error {
 	if clc.recordType == "" {
 		return &FieldError{FieldName: "recordType",
 			Value: clc.recordType,
@@ -165,12 +165,15 @@ func (clc *CashLetterControl) fieldInclusion(collectionTypeIndicator string) err
 			Value: clc.CashLetterTotalAmountField(),
 			Msg:   msgFieldInclusion + ", did you use CashLetterControl()?"}
 	}
-	// If the type of the cash letter control is `Return`, we do not require to have this field present.
-	if clc.SettlementDate.IsZero() && !isReturnCollectionType(collectionTypeIndicator) {
-		return &FieldError{FieldName: "SettlementDate",
-			Value: clc.SettlementDate.String(),
-			Msg:   msgFieldInclusion + ", did you use CashLetterControl()?"}
+
+	// optional field - if present, year must be between 1993 and 9999
+	if date := clc.SettlementDate; !date.IsZero() {
+		if date.Year() < 1993 || date.Year() > 9999 {
+			return &FieldError{FieldName: "SettlementDate",
+				Value: clc.SettlementDateField(), Msg: msgInvalidDate + ": year must be between 1993 and 9999"}
+		}
 	}
+
 	return nil
 }
 

--- a/reader.go
+++ b/reader.go
@@ -303,7 +303,7 @@ func (r *Reader) parseLine() error { //nolint:gocyclo
 		if header == nil {
 			return errors.New("missing CashLetterHeader")
 		}
-		if err := r.parseCashLetterControl(header.CollectionTypeIndicator); err != nil {
+		if err := r.parseCashLetterControl(); err != nil {
 			return err
 		}
 		if err := r.currentCashLetter.Validate(); err != nil {
@@ -707,7 +707,7 @@ func (r *Reader) parseRoutingNumberSummary() error {
 }
 
 // parseCashLetterControl takes the input record string and parses the CashLetterControl values
-func (r *Reader) parseCashLetterControl(collectionTypeIndicator string) error {
+func (r *Reader) parseCashLetterControl() error {
 	r.recordName = "CashLetterControl"
 	if r.currentCashLetter.CashLetterHeader == nil {
 		// CashLetterControl without a current CashLetter
@@ -715,7 +715,7 @@ func (r *Reader) parseCashLetterControl(collectionTypeIndicator string) error {
 	}
 	r.currentCashLetter.GetControl().Parse(r.decodeLine(r.line))
 	// Ensure valid CashLetterControl
-	if err := r.currentCashLetter.GetControl().Validate(collectionTypeIndicator); err != nil {
+	if err := r.currentCashLetter.GetControl().Validate(); err != nil {
 		return r.error(err)
 	}
 	return nil


### PR DESCRIPTION
The current validation logic treats CashLetterControl.SettlementDate as mandatory under certain conditions, but the specifications say this field "Shall be present only under clearing arrangements". Removing this field requirement allows this library to support a wider variety of Image Cash Letter formats.