### PR TITLE
openapi: add quotes to payorBankCheckDigit example value

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1221,7 +1221,7 @@ components:
             PayorBankCheckDigit identifies the routing number check digit.  The
             combination of Payor Bank Routing Number and Payor Bank Routing Number Check Digit must be a mod-checked
             routing number with a valid check digit.
-          example: 5
+          example: '5'
         onUs:
           type: string
           maxLength: 20


### PR DESCRIPTION
The missing quotes around this example value seem to be causing our hosted API documentation to create an example request body with an integer value instead of a string, despite the field's type being `string`.