### PR TITLE
fix: Allow empty EndorsingBankItemSequenceNumber in FRB mode

### DIFF
--- a/CheckDetailAddendumC.go
+++ b/CheckDetailAddendumC.go
@@ -248,7 +248,7 @@ func (cdAddendumC *CheckDetailAddendumC) fieldInclusion() error {
 			Value: cdAddendumC.BOFDEndorsementBusinessDate.String(),
 			Msg:   msgFieldInclusion + ", did you use CheckDetailAddendumC()?"}
 	}
-	if cdAddendumC.EndorsingBankItemSequenceNumberField() == "               " {
+	if !IsFRBCompatibilityModeEnabled() && cdAddendumC.EndorsingBankItemSequenceNumberField() == "               " {
 		return &FieldError{FieldName: "EndorsingBankItemSequenceNumber",
 			Value: cdAddendumC.EndorsingBankItemSequenceNumber,
 			Msg:   msgFieldInclusion + ", did you use CheckDetailAddendumC()?"}


### PR DESCRIPTION
Fix for: https://github.com/tesseract-ocr/tesseract/issues/4310