### PR TITLE
skip ReturnLocationRoutingNumber zero validation in FRB mode

### DIFF
--- a/checkDetailAddendumA.go
+++ b/checkDetailAddendumA.go
@@ -240,10 +240,12 @@ func (cdAddendumA *CheckDetailAddendumA) fieldInclusion() error {
 			Value: cdAddendumA.ReturnLocationRoutingNumber,
 			Msg:   msgFieldInclusion + ", did you use CheckDetailAddendumA()?"}
 	}
-	if cdAddendumA.ReturnLocationRoutingNumberField() == "000000000" {
-		return &FieldError{FieldName: "ReturnLocationRoutingNumber",
-			Value: cdAddendumA.ReturnLocationRoutingNumber,
-			Msg:   msgFieldInclusion + ", did you use CheckDetailAddendumA()?"}
+	if !IsFRBCompatibilityModeEnabled() {
+		if cdAddendumA.ReturnLocationRoutingNumberField() == "000000000" {
+			return &FieldError{FieldName: "ReturnLocationRoutingNumber",
+				Value: cdAddendumA.ReturnLocationRoutingNumber,
+				Msg:   msgFieldInclusion + ", did you use CheckDetailAddendumA()?"}
+		}
 	}
 	if cdAddendumA.BOFDEndorsementDate.IsZero() {
 		return &FieldError{FieldName: "BOFDEndorsementDate",

--- a/checkDetailAddendumA_test.go
+++ b/checkDetailAddendumA_test.go
@@ -263,6 +263,15 @@ func TestCDAddendumAFIReturnLocationRoutingNumberZero(t *testing.T) {
 	require.Equal(t, "ReturnLocationRoutingNumber", e.FieldName)
 }
 
+func TestCDAddendumAFIReturnLocationRoutingNumberZeroFRB(t *testing.T) {
+	cdAddendumA := mockCheckDetailAddendumA()
+	cdAddendumA.ReturnLocationRoutingNumber = "000000000"
+	// enable FRB mode and verify it passes
+	t.Setenv(FRBCompatibilityMode, "true")
+	require.NoError(t, cdAddendumA.Validate())
+	t.Setenv(FRBCompatibilityMode, "")
+}
+
 // TestCDAddendumAFIBOFDEndorsementDate validation
 func TestCDAddendumAFIBOFDEndorsementDate(t *testing.T) {
 	cdAddendumA := mockCheckDetailAddendumA()


### PR DESCRIPTION
Modifies ReturnLocationRoutingNumber validation to skip the 000000000 value check when FRB compatibility mode is enabled. 