### PR TITLE
Add support for return code N for CashLetterHeader.ReturnsIndicator

### DIFF
--- a/cashLetterHeader.go
+++ b/cashLetterHeader.go
@@ -135,6 +135,7 @@ type CashLetterHeader struct {
 	// affect the customer or its account.
 	// R: Customer–items being returned that directly affect a customer’s account.
 	// J: Reject Return
+	// N: Altered/fictitious Item. Suspected counterfeit/counterfeit
 	ReturnsIndicator string `json:"returnsIndicator"`
 	// UserField is a field used at the discretion of users of the standard.
 	UserField string `json:"userField"`

--- a/cashLetterHeader_test.go
+++ b/cashLetterHeader_test.go
@@ -183,12 +183,54 @@ func TestFedWorkType(t *testing.T) {
 
 // TestReturnsIndicator validation
 func TestReturnsIndicator(t *testing.T) {
+	testCases := []struct {
+		name             string
+		returnsIndicator string
+		err              bool
+	}{
+		{
+			name:             "Invalid ReturnsIndicator",
+			returnsIndicator: "A",
+			err:              true,
+		},
+		{
+			name:             "Valid ReturnsIndicator empty",
+			returnsIndicator: "",
+			err:              false,
+		},
+		{
+			name:             "Valid ReturnsIndicator E",
+			returnsIndicator: "E",
+			err:              false,
+		},
+		{
+			name:             "Valid ReturnsIndicator R",
+			returnsIndicator: "R",
+			err:              false,
+		},
+		{
+			name:             "Valid ReturnsIndicator J",
+			returnsIndicator: "J",
+			err:              false,
+		},
+		{
+			name:             "Valid ReturnsIndicator N",
+			returnsIndicator: "N",
+			err:              false,
+		},
+	}
 	clh := mockCashLetterHeader()
-	clh.ReturnsIndicator = "A"
-	err := clh.Validate()
 	var e *FieldError
-	require.ErrorAs(t, err, &e)
-	require.Equal(t, "ReturnsIndicator", e.FieldName)
+	for _, tc := range testCases {
+		clh.ReturnsIndicator = tc.returnsIndicator
+		err := clh.Validate()
+		if tc.err {
+			require.ErrorAs(t, err, &e)
+			require.Equal(t, "ReturnsIndicator", e.FieldName)
+		} else {
+			require.NoError(t, err)
+		}
+	}
 }
 
 // TestCLHUserField validation

--- a/validators.go
+++ b/validators.go
@@ -257,7 +257,9 @@ func (v *validator) isReturnsIndicator(code string) error {
 		// Customer–items being returned that directly affect a customer’s account.
 		"R",
 		// Reject Return
-		"J":
+		"J",
+		// Altered/Fictitious Item/Suspected Counterfeit/Counterfeit
+		"N":
 		return nil
 	}
 	return errors.New(msgInvalid)


### PR DESCRIPTION
issue: https://github.com/moov-io/imagecashletter/issues/400

We are running into `ReturnsIndicator N is invalid` error when parsing x9 files we receive from banks. This is an attempt to resolve that error by adding support to a new return code in the header.

We got the return code from https://x9.org/wp-content/uploads/2016/11/ANSI-X9-100-188-2016.pdf 

If this is not the way, please guide us to a better way to address this. 