### PR TITLE
Addenda record numbers

### DIFF
--- a/cashLetter.go
+++ b/cashLetter.go
@@ -179,7 +179,7 @@ func (cl *CashLetter) build() error {
 			}
 			for x := range cd.CheckDetailAddendumC {
 				cd.CheckDetailAddendumC[x].SetEndorsingBankItemSequenceNumber(cdSequenceNumber)
-				cd.CheckDetailAddendumC[x].RecordNumber = cdAddendumARecordNumber
+				cd.CheckDetailAddendumC[x].RecordNumber = cdAddendumCRecordNumber
 				cdAddendumCRecordNumber++
 				if cdAddendumCRecordNumber > 99 {
 					cdAddendumCRecordNumber = 1

--- a/cashLetter.go
+++ b/cashLetter.go
@@ -178,7 +178,9 @@ func (cl *CashLetter) build() error {
 				}
 			}
 			for x := range cd.CheckDetailAddendumC {
-				cd.CheckDetailAddendumC[x].SetEndorsingBankItemSequenceNumber(cdSequenceNumber)
+				if cd.CheckDetailAddendumC[x].EndorsingBankItemSequenceNumber != "" {
+					cd.CheckDetailAddendumC[x].SetEndorsingBankItemSequenceNumber(cdSequenceNumber)
+				}
 				cd.CheckDetailAddendumC[x].RecordNumber = cdAddendumCRecordNumber
 				cdAddendumCRecordNumber++
 				if cdAddendumCRecordNumber > 99 {

--- a/cashLetter_test.go
+++ b/cashLetter_test.go
@@ -70,9 +70,19 @@ func TestCashLetter_customSequenceNumber(t *testing.T) {
 	checkBundle := NewBundle(checkBundleHeader)
 	cd := mockCheckDetail()
 	cd.SetEceInstitutionItemSequenceNumber(283)
-	cd.AddendumCount = 2
-	cd.AddCheckDetailAddendumA(mockCheckDetailAddendumA())
-	cd.AddCheckDetailAddendumC(mockCheckDetailAddendumC())
+	cd.AddendumCount = 4
+	firstAddendumA := mockCheckDetailAddendumA()
+	firstAddendumA.RecordNumber = 1
+	cd.AddCheckDetailAddendumA(firstAddendumA)
+	secondAddendumA := mockCheckDetailAddendumA()
+	secondAddendumA.RecordNumber = 2
+	cd.AddCheckDetailAddendumA(secondAddendumA)
+	firstAddendumC := mockCheckDetailAddendumC()
+	firstAddendumC.RecordNumber = 1
+	cd.AddCheckDetailAddendumC(firstAddendumC)
+	secondAddendumC := mockCheckDetailAddendumC()
+	secondAddendumC.RecordNumber = 2
+	cd.AddCheckDetailAddendumC(secondAddendumC)
 	checkBundle.AddCheckDetail(cd)
 
 	// Create a return bundle
@@ -99,8 +109,18 @@ func TestCashLetter_customSequenceNumber(t *testing.T) {
 	require.Len(t, cl.Bundles[0].Checks, 1)
 	wantCheckSeq := "000000000000283"
 	require.Equal(t, wantCheckSeq, cl.Bundles[0].Checks[0].EceInstitutionItemSequenceNumber)
-	require.Equal(t, wantCheckSeq, cl.Bundles[0].Checks[0].CheckDetailAddendumC[0].EndorsingBankItemSequenceNumber)
+
+	// CheckDetailAddendumA
+	require.Len(t, cl.Bundles[0].Checks[0].CheckDetailAddendumA, 2)
+	require.Equal(t, 1, cl.Bundles[0].Checks[0].CheckDetailAddendumA[0].RecordNumber)
+	require.Equal(t, 2, cl.Bundles[0].Checks[0].CheckDetailAddendumA[1].RecordNumber)
 	require.Equal(t, wantCheckSeq, cl.Bundles[0].Checks[0].CheckDetailAddendumA[0].BOFDItemSequenceNumber)
+
+	// CheckDetailAddendumC
+	require.Len(t, cl.Bundles[0].Checks[0].CheckDetailAddendumC, 2)
+	require.Equal(t, 1, cl.Bundles[0].Checks[0].CheckDetailAddendumC[0].RecordNumber)
+	require.Equal(t, 2, cl.Bundles[0].Checks[0].CheckDetailAddendumC[1].RecordNumber)
+	require.Equal(t, wantCheckSeq, cl.Bundles[0].Checks[0].CheckDetailAddendumC[0].EndorsingBankItemSequenceNumber)
 
 	require.Len(t, cl.Bundles[1].Returns, 1)
 	wantReturnSeq := "000000000004923"


### PR DESCRIPTION
Fixes a likely copy/paste bug in handling of Check Detail Addendum C Record Number. Also addresses a concern where custom Endorsing Bank Item Sequence Number was being overwritten. 

Closes #413 