### PR TITLE
fix(cors): allowlist Origins via MOOV_CORS_ALLOW_ORIGINS

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,12 +19,12 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/moov-io/base/admin"
-	moovhttp "github.com/moov-io/base/http"
 	"github.com/moov-io/base/http/bind"
 	"github.com/moov-io/base/log"
 	"github.com/moov-io/imagecashletter"
 	"github.com/moov-io/imagecashletter/internal/files"
 	v2files "github.com/moov-io/imagecashletter/internal/files/v2"
+	"github.com/moov-io/imagecashletter/internal/metrics"
 	"github.com/moov-io/imagecashletter/internal/storage"
 )
 
@@ -86,7 +86,7 @@ func main() {
 	serverValidateOpts := getValidateOptsFromEnv()
 
 	router := mux.NewRouter()
-	moovhttp.AddCORSHandler(router)
+	addCORSHandler(router)
 	addPingRoute(router)
 	files.AppendRoutes(logger, router, repository, serverValidateOpts)
 	v2files.NewController(logger, repository, serverValidateOpts).AddRoutes(router)
@@ -145,9 +145,21 @@ func main() {
 	}
 }
 
+func addCORSHandler(r *mux.Router) {
+	r.Methods("OPTIONS").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		origin := req.Header.Get("Origin")
+		if origin == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		metrics.SetAccessControlAllowHeaders(w, origin)
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
 func addPingRoute(r *mux.Router) {
 	r.Methods("GET").Path("/ping").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		moovhttp.SetAccessControlAllowHeaders(w, r.Header.Get("Origin"))
+		metrics.SetAccessControlAllowHeaders(w, r.Header.Get("Origin"))
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("PONG"))

--- a/internal/metrics/cors.go
+++ b/internal/metrics/cors.go
@@ -1,0 +1,108 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package metrics
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/metrics"
+	"github.com/moov-io/base/log"
+)
+
+// CORSAllowedOriginsEnv is a comma-separated list of exact Origins permitted for
+// credentialed CORS. Example: "https://moov.io,https://dashboard.moov.io".
+// Localhost (http://localhost:<port>) remains allowed for development.
+//
+// Temporary ImageCashLetter-local allowlist until moov-io/base#509 lands and is bumped here.
+const CORSAllowedOriginsEnv = "MOOV_CORS_ALLOW_ORIGINS"
+
+var (
+	corsAllowlistOnce sync.Once
+	corsAllowlist     map[string]struct{}
+)
+
+func loadCORSAllowlist() map[string]struct{} {
+	corsAllowlistOnce.Do(func() {
+		corsAllowlist = make(map[string]struct{})
+		for _, part := range strings.Split(os.Getenv(CORSAllowedOriginsEnv), ",") {
+			origin := strings.TrimSpace(part)
+			if origin != "" {
+				corsAllowlist[origin] = struct{}{}
+			}
+		}
+	})
+	return corsAllowlist
+}
+
+// ResetCORSAllowlistForTest clears the cached allowlist. Intended for tests only.
+func ResetCORSAllowlistForTest() {
+	corsAllowlistOnce = sync.Once{}
+	corsAllowlist = nil
+}
+
+func originAllowedForCORS(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	if strings.HasPrefix(origin, "http://localhost:") {
+		return true
+	}
+	_, ok := loadCORSAllowlist()[origin]
+	return ok
+}
+
+// SetAccessControlAllowHeaders writes Access-Control-Allow-* headers only for
+// allowlisted Origins. Do not call moov-io/base's reflector until it gains an
+// allowlist (base#509).
+func SetAccessControlAllowHeaders(w http.ResponseWriter, origin string) {
+	if !originAllowedForCORS(origin) {
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PATCH,DELETE,OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Cookie,X-User-Id,X-Request-Id,Content-Type")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	start          time.Time
+	request        *http.Request
+	metric         metrics.Histogram
+	headersWritten bool
+	log            log.Logger
+}
+
+func (w *responseWriter) WriteHeader(code int) {
+	if w == nil || w.headersWritten {
+		return
+	}
+	w.headersWritten = true
+	SetAccessControlAllowHeaders(w, w.request.Header.Get("Origin"))
+	defer w.ResponseWriter.WriteHeader(code)
+
+	diff := time.Since(w.start)
+	if w.metric != nil {
+		w.metric.Observe(diff.Seconds())
+	}
+	if w.ResponseWriter.Header().Get("Content-Type") == "" {
+		w.ResponseWriter.Header().Set("Content-Type", "text/plain")
+		w.ResponseWriter.Header().Set("X-Content-Type-Options", "nosniff")
+	}
+}
+
+func wrapResponseWriterAllowlist(logger log.Logger, m metrics.Histogram, w http.ResponseWriter, r *http.Request) http.ResponseWriter {
+	return &responseWriter{
+		ResponseWriter: w,
+		start:          time.Now(),
+		request:        r,
+		metric:         m,
+		log:            logger,
+	}
+}

--- a/internal/metrics/cors_test.go
+++ b/internal/metrics/cors_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package metrics
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func withCORSAllowOrigins(t *testing.T, origins string) {
+	t.Helper()
+	t.Setenv(CORSAllowedOriginsEnv, origins)
+	ResetCORSAllowlistForTest()
+	t.Cleanup(ResetCORSAllowlistForTest)
+}
+
+func TestCORSRejectsUnlistedOrigin(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+	w := httptest.NewRecorder()
+	SetAccessControlAllowHeaders(w, "https://evil.example")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "" {
+		t.Errorf("expected no ACAO, got %q", v)
+	}
+}
+
+func TestCORSAllowsListedOrigin(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+	w := httptest.NewRecorder()
+	SetAccessControlAllowHeaders(w, "https://moov.io")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "https://moov.io" {
+		t.Errorf("got %q", v)
+	}
+	if v := w.Header().Get("Access-Control-Allow-Credentials"); v != "true" {
+		t.Errorf("got credentials %q", v)
+	}
+}
+
+func TestCORSAllowsLocalhost(t *testing.T) {
+	withCORSAllowOrigins(t, "")
+	w := httptest.NewRecorder()
+	SetAccessControlAllowHeaders(w, "http://localhost:3000")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "http://localhost:3000" {
+		t.Errorf("got %q", v)
+	}
+}

--- a/internal/metrics/http.go
+++ b/internal/metrics/http.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	moovhttp "github.com/moov-io/base/http"
 	"github.com/moov-io/base/log"
 
 	"github.com/go-kit/kit/metrics/prometheus"
@@ -27,7 +26,7 @@ var (
 
 func WrapResponseWriter(logger log.Logger, w http.ResponseWriter, r *http.Request) http.ResponseWriter {
 	route := fmt.Sprintf("%s-%s", strings.ToLower(r.Method), cleanMetricsPath(r.URL.Path))
-	return moovhttp.Wrap(logger, routeHistogram.With("route", route), w, r)
+	return wrapResponseWriterAllowlist(logger, routeHistogram.With("route", route), w, r)
 }
 
 var baseIdRegex = regexp.MustCompile(`([a-f0-9]{40})`)


### PR DESCRIPTION
## Summary
- Credentialed CORS previously came from `moov-io/base` `Wrap` / `AddCORSHandler` / `SetAccessControlAllowHeaders`, which reflect any `https://` Origin with credentials.
- ImageCashLetter-local allowlist via `MOOV_CORS_ALLOW_ORIGINS` until base#509 is bumped. Localhost retained for development.
- Sibling of ach#1830, fed#443, customers/wire CORS PRs.

## Test plan
- [x] `go test ./internal/metrics/ -count=1`
- [ ] Set `MOOV_CORS_ALLOW_ORIGINS` in deploy and confirm unlisted Origins get no ACAO

Tooling assist: Cursor agent helped prepare this PR; commits are authored and signed by me (no Cursor co-author trailer).

Made with [Cursor](https://cursor.com)