### PR TITLE
fix(http): ignore non-boolean skipAll and skipCountValidation

### DIFF
--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -103,7 +103,8 @@ func determineBufferSize(env string, nominal int) int {
 
 // ValidateOptsFromRequest extracts ValidateOpts (e.g. skipAll, skipCountValidation)
 // from query parameters on the HTTP request. This enables per-request control over
-// validation when creating files via the API. Unrecognized or absent params are ignored.
+// validation when creating files via the API. Unrecognized, absent, or non-boolean
+// params are ignored (invalid values must not enable a skip).
 func ValidateOptsFromRequest(r *http.Request) *imagecashletter.ValidateOpts {
 	q := r.URL.Query()
 
@@ -114,8 +115,6 @@ func ValidateOptsFromRequest(r *http.Request) *imagecashletter.ValidateOpts {
 			opts.SkipAll = true
 		} else if b, err := strconv.ParseBool(v); err == nil {
 			opts.SkipAll = b
-		} else {
-			opts.SkipAll = true
 		}
 	}
 	if vals := q["skipCountValidation"]; len(vals) > 0 {
@@ -124,8 +123,6 @@ func ValidateOptsFromRequest(r *http.Request) *imagecashletter.ValidateOpts {
 			opts.SkipCountValidation = true
 		} else if b, err := strconv.ParseBool(v); err == nil {
 			opts.SkipCountValidation = b
-		} else {
-			opts.SkipCountValidation = true
 		}
 	}
 	if !opts.SkipAll && !opts.SkipCountValidation {

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -19,6 +19,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateOptsFromRequest_invalidBoolDoesNotSkip(t *testing.T) {
+	req := httptest.NewRequest("POST", "/files/create?skipAll=xyzzy", nil)
+	require.Nil(t, ValidateOptsFromRequest(req))
+
+	req = httptest.NewRequest("POST", "/files/create?skipCountValidation=xyzzy", nil)
+	require.Nil(t, ValidateOptsFromRequest(req))
+
+	req = httptest.NewRequest("POST", "/files/create?skipAll=true", nil)
+	opts := ValidateOptsFromRequest(req)
+	require.NotNil(t, opts)
+	require.True(t, opts.SkipAll)
+}
+
 func TestFileId(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/foo", nil)
@@ -152,6 +165,18 @@ func TestFiles_createFile_withValidateOpts(t *testing.T) {
 		resp, file := env.createFileWithQuery(t, "application/json", mismatchedAddendumJSON(t), "skipAll=true")
 		require.Equal(t, http.StatusCreated, resp.Code, resp.Body)
 		require.NotEmpty(t, file.ID)
+	})
+
+	t.Run("json: invalid skipAll does not bypass validation", func(t *testing.T) {
+		env := newTestEnvironment(t)
+		resp, _ := env.createFileWithQuery(t, "application/json", mismatchedAddendumJSON(t), "skipAll=xyzzy")
+		require.Equal(t, http.StatusBadRequest, resp.Code, resp.Body)
+	})
+
+	t.Run("json: invalid skipCountValidation does not bypass validation", func(t *testing.T) {
+		env := newTestEnvironment(t)
+		resp, _ := env.createFileWithQuery(t, "application/json", mismatchedAddendumJSON(t), "skipCountValidation=xyzzy")
+		require.Equal(t, http.StatusBadRequest, resp.Code, resp.Body)
 	})
 
 	t.Run("json: SkipCountValidation via per-request query param allows the file", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `ValidateOptsFromRequest` treated a `strconv.ParseBool` error as `true`, so `POST /files/create?skipAll=xyzzy` (or `skipCountValidation=xyzzy`) skipped ICL validation and stored the file.
- Invalid values are now ignored, matching the existing "unrecognized params are ignored" contract. `skipAll=true` / `skipAll=false` / bare `?skipAll` are unchanged.
- Revert-test: `TestValidateOptsFromRequest_invalidBoolDoesNotSkip` fails if the parse-error branch sets SkipAll again.

## Test plan
- [x] `go test ./internal/files/ -count=1`
- [x] Revert the parse-error branch locally and watch the new unit test fail

Tooling assist: Cursor agent helped prepare this PR. Commits are authored and signed by me (no Cursor co-author trailer).

Made with [Cursor](https://cursor.com)